### PR TITLE
Ignore out directory for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .gradle
 build/
 *.iml
+out
 captures/
 local.properties


### PR DESCRIPTION
Running tests from IntelliJ creates an 'out' directory. 