### PR TITLE
Change jdk to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script:
   - ./ci.sh


### PR DESCRIPTION
Builds are failing ([1](https://travis-ci.org/github/vanniktech/RxRiddles/builds/578447758), [2](https://travis-ci.org/github/vanniktech/RxRiddles/builds/685591327)) in Travis:

```
Installing oraclejdk8
$ export JAVA_HOME=~/oraclejdk8
$ export PATH="$JAVA_HOME/bin:$PATH"
$ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
Ignoring license option: BCL -- using GPLv2+CE by default
install-jdk.sh 2020-03-17
Expected feature release number in range of 9 to 15, but got: 8
The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
```

Changing it to openjdk8 in order to try to fix it.